### PR TITLE
Social

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 staging/working
 lit-mode/
+test.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 staging/working
+lit-mode/

--- a/system/quantity-script.js
+++ b/system/quantity-script.js
@@ -1,6 +1,7 @@
 // Initialization functinos
 document.addEventListener('DOMContentLoaded', function() {
 	buildTOC()
+	convertSocials()
 });
 
 
@@ -30,5 +31,68 @@ function buildTOC() {
 		toc_ul.appendChild(toc_li)
 
 	}
+
+}
+
+
+
+// Converts <social> tags to links
+function convertSocials() {
+
+	// Get the social tags
+	const social_tags = document.getElementsByTagName("social")
+
+	// Loop through the social tags
+	while (social_tags.length > 0) {
+
+		// Get the info from the <social> tag
+		social = social_tags[0]
+		platform = social.getAttribute("platform")
+		handle = social.textContent
+
+		// Send info the function below, returns an object with url and text.
+		social_obj = getPlatformUrl(platform, handle)
+		console.log(social_obj)
+
+		// build the link text
+		let social_link = document.createElement("a")
+		social_link.href = social_obj["url"]
+		social_link.innerHTML = social_obj["text"]
+
+		// Get the parent div and append the new link
+		let parent_h5 = social.parentNode
+		parent_h5.appendChild(social_link)
+
+		// Delete the <social> tag
+		social.remove()
+	}
+
+
+	function getPlatformUrl(p, h) {
+		switch(p) {
+
+			case("instagram"):
+				return({
+					"text" : ("ig @" + h + "<br>"),
+					"url" : ("https://www.instagram.com/" + h)
+					})
+				break;
+
+			case("twitter"):
+				return({
+					"text" : ("tw @" + h + "<br>"),
+					"url": ("https://twitter.com/" + h)
+				})
+				break;
+
+			case("tiktok"):
+				return({
+					"text" : ("tk @" + h + "<br>"),
+					"url" : ("https://www.tiktok.com/@" + h)
+				})
+				break;
+		}
+	}
+
 
 }


### PR DESCRIPTION
Added a function which, when the page loads, converts <social> tags to standard links.

The syntax in HTML is: <social platform="instagram">handle</social>

platform options right now are "instagram", "twitter", and "tiktok" -- they _have_ to be this text exactly. (It's easy to add more, though.) No need to add the @ before the handle, and the code will add a link break between the tags.